### PR TITLE
Update package.json to include manual async/request install

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,14 +43,6 @@ Install [Redis](http://redis.io/download) and start Redis. For all *nix systems,
 Install dependent Node.js modules based on package.json declaration
 
     $ npm install  <in-your-winecellar-home>
-    
-Install “request” & “async” modules explicitly
-
-    npm install request async
-
-Install [forever](https://www.npmjs.org/package/forever)
-
-    npm -g install forever
 
 Install Node.js Agent
 -----------------

--- a/package.json
+++ b/package.json
@@ -1,16 +1,18 @@
 {
-    "name": "wine-cellar",
-    "description": "Wine Cellar Application",
-    "version": "0.0.1",
-    "private": true,
-    "dependencies": {
-        "express": "3.x",
-        "mongodb": "1.1.8",
-        "socket.io": "0.9.10",
-	"redis":"*"
-    },
-    "engines": {
-        "node": "0.8.4",
-        "npm": "1.1.49"
-    }
+  "name": "wine-cellar",
+  "description": "Wine Cellar Application",
+  "version": "0.0.1",
+  "private": true,
+  "dependencies": {
+    "express": "3.x",
+    "mongodb": "1.1.8",
+    "socket.io": "0.9.10",
+    "redis": "*",
+    "async": "^0.7.0",
+    "request": "^2.34.0"
+  },
+  "engines": {
+    "node": "0.8.4",
+    "npm": "1.1.49"
+  }
 }


### PR DESCRIPTION
This removes the need to install these modules manually,
as they are included in the default `npm install`.
